### PR TITLE
Add system property to turn off send error logging

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ subprojects {
     }
 
     group = "club.minnced"
-    version = "0.1.6-rc"
+    version = "0.1.7"
 
     // See https://github.com/sedmelluq/lavaplayer/blob/master/common/src/main/java/com/sedmelluq/lava/common/natives/architecture/DefaultArchitectureTypes.java
     // identifier is the suffix used after the system name


### PR DESCRIPTION
With this, you could do `-Dudpqueue.log_errors=false` to turn off error logging during the send process. This might be worth doing in cases where the internet is known to have issues.

Right now, all errors are logged by default, to allow for easy debugging. However, it might be desirable to disable this in a production environment. Doing this at runtime is also possible with `System.setProperty("udpqueue.log_errors", "false")`.