### PR TITLE
Optimizations and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.6 - 2022/12/01
+
+- Some memory and efficiency improvements
+
 ## v0.2.5 - 2022/09/04
 
 - Make IPv6 optional and improve socket ownership (#5)

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ dependencies {
 ```gradle
 dependencies {
     // Fully modular, choose which platforms to use!
-    implementation("club.minnced:udpqueue-native-linux-x86-64:0.2.5") // adds linux 64bit
-    implementation("club.minnced:udpqueue-native-win-x86-64:0.2.5") // adds windows 64bit
+    implementation("club.minnced:udpqueue-native-linux-x86-64:0.2.6") // adds linux 64bit
+    implementation("club.minnced:udpqueue-native-win-x86-64:0.2.6") // adds windows 64bit
 }
 ```
 
@@ -68,12 +68,12 @@ To add all supported platforms, you can use this:
 
 ```gradle
 dependencies {
-    implementation("club.minnced:udpqueue-native-linux-x86-64:0.2.5")
-    implementation("club.minnced:udpqueue-native-linux-x86:0.2.5")
-    implementation("club.minnced:udpqueue-native-linux-aarch64:0.2.5")
-    implementation("club.minnced:udpqueue-native-linux-arm:0.2.5")
-    implementation("club.minnced:udpqueue-native-win-x86-64:0.2.5")
-    implementation("club.minnced:udpqueue-native-win-x86:0.2.5")
-    implementation("club.minnced:udpqueue-native-darwin:0.2.5")
+    implementation("club.minnced:udpqueue-native-linux-x86-64:0.2.6")
+    implementation("club.minnced:udpqueue-native-linux-x86:0.2.6")
+    implementation("club.minnced:udpqueue-native-linux-aarch64:0.2.6")
+    implementation("club.minnced:udpqueue-native-linux-arm:0.2.6")
+    implementation("club.minnced:udpqueue-native-win-x86-64:0.2.6")
+    implementation("club.minnced:udpqueue-native-win-x86:0.2.6")
+    implementation("club.minnced:udpqueue-native-darwin:0.2.6")
 }
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ subprojects {
     }
 
     group = "club.minnced"
-    version = "0.2.5"
+    version = "0.2.6"
 
     // See https://github.com/sedmelluq/lavaplayer/blob/master/common/src/main/java/com/sedmelluq/lava/common/natives/architecture/DefaultArchitectureTypes.java
     // identifier is the suffix used after the system name

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "udpqueue"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "jni",
 ]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udpqueue"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 
 [dependencies]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -13,3 +13,4 @@ crate_type = ["cdylib"]
 opt-level = 3
 lto = true
 strip = "debuginfo"
+panic = "abort"

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -300,12 +300,12 @@ use windows_specific::*;
 #[cfg(not(any(unix, windows)))]
 mod fallback {
     #[inline(always)]
-    pub unsafe fn to_socket(handle: jlong) -> UdpSocket {
+    pub(crate) unsafe fn to_socket(handle: jlong) -> UdpSocket {
         panic!("Cannot convert UdpSocket handle for this platform");
     }
 
     #[inline(always)]
-    pub unsafe fn to_fd(socket: UdpSocket) -> RawFd {
+    pub(crate) unsafe fn to_fd(socket: UdpSocket) -> RawFd {
         panic!("Cannot convert UdpSocket handle for this platform");
     }
 }
@@ -316,12 +316,12 @@ mod unix_specific {
     use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
 
     #[inline(always)]
-    pub unsafe fn to_socket(handle: jlong) -> UdpSocket {
+    pub(crate) unsafe fn to_socket(handle: jlong) -> UdpSocket {
         UdpSocket::from_raw_fd(handle as RawFd)
     }
 
     #[inline(always)]
-    pub unsafe fn to_fd(socket: UdpSocket) -> RawFd {
+    pub(crate) unsafe fn to_fd(socket: UdpSocket) -> RawFd {
         socket.into_raw_fd()
     }
 }
@@ -332,12 +332,12 @@ mod windows_specific {
     use std::os::windows::io::{FromRawSocket, IntoRawSocket, RawSocket};
 
     #[inline(always)]
-    pub unsafe fn to_socket(handle: jlong) -> UdpSocket {
+    pub(crate) unsafe fn to_socket(handle: jlong) -> UdpSocket {
         UdpSocket::from_raw_socket(handle as RawSocket)
     }
 
     #[inline(always)]
-    pub unsafe fn to_fd(socket: UdpSocket) -> RawSocket {
+    pub(crate) unsafe fn to_fd(socket: UdpSocket) -> RawSocket {
         socket.into_raw_socket()
     }
 }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -18,8 +18,10 @@ fn parse_address(
     string: JString,
     port: jint,
 ) -> Result<SocketAddr, Box<dyn std::error::Error>> {
-    let s = format!("{}:{}", env.get_string(string)?.to_str()?, port);
-    Ok(s.parse()?)
+    Ok(SocketAddr::new(
+        env.get_string(string)?.to_str()?.parse()?,
+        port as u16,
+    ))
 }
 
 #[inline(always)]


### PR DESCRIPTION
1. Use `abort()` for panics rather than unwinding. Removes unneeded unwinding code/symbols from binary.
2. Avoid parsing port of socket address. Removes redundant formatter usage and simplifies address creation.
3. Lower visibility for internals to avoid leaking symbols.